### PR TITLE
Create Notion Page From Release Notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
 MIT License
 
-Copyright (c) 2021 Infinitas Learning Technology B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Notion release notes'
-description: 'Creates a new page in an existing database to capture release notes'
+name: 'Notion create page from markdown file'
+description: 'Creates a new page in an existing database to capture content of a markdown file'
 branding:
   icon: type
   color: green
@@ -13,15 +13,12 @@ inputs:
   name:  
     description: 'Name for the release'
     required: true
-  body:  
-    description: 'Body content for release notes'
+  filepath:  
+    description: 'The path to the file to add to Notion' 
     required: true
-  tags:  
-    description: 'Comma separated tag list'
-    required: false
 outputs:
   status: 
     description: 'The status of the update'
 runs:
-  using: 'node12'
+  using: 'node18'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/github": "^5.0.0",
-        "@notionhq/client": "^0.4.11",
-        "@tryfabric/martian": "^1.1.1"
+        "@notionhq/client": "^2.2.5",
+        "@tryfabric/martian": "^1.2.4"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-0.4.11.tgz",
-      "integrity": "sha512-+zT+qBHx8V6Fj3Tj9a4KKfYE4tWhrS/7A5OWRinEjsL5J0GKskQ5EnnLEejptg0COh6BgJShVQLPJXsr0NovLQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.5.tgz",
+      "integrity": "sha512-NobSaeSK0DMuxAIy2pg53Iv850tGFxXYEYacFBQgO634L1uwQv7WQCAdeFQpD3kJiEycQfSYv6RGC5VENEXjiQ==",
       "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
@@ -1128,17 +1128,30 @@
       }
     },
     "node_modules/@tryfabric/martian": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.1.1.tgz",
-      "integrity": "sha512-7EC6np65doCeaJHubyoJzYa8dykKw069QQwV1AdRce0Epw4+eOfXQcYmmXnNHpvJYCctst/Nkjo0lQA6H1UPqQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.2.4.tgz",
+      "integrity": "sha512-g7SP7beaxrjxLnW//vskra07a1jsJowqp07KMouxh4gCwaF+ItHbRZN8O+1dhJivBi3VdasT71BPyk+8wzEreQ==",
       "dependencies": {
-        "@notionhq/client": "^0.4.5",
+        "@notionhq/client": "^1.0.4",
         "remark-gfm": "^1.0.0",
+        "remark-math": "^4.0.0",
         "remark-parse": "^9.0.0",
         "unified": "^9.2.1"
       },
       "engines": {
         "node": ">=15"
+      }
+    },
+    "node_modules/@tryfabric/martian/node_modules/@notionhq/client": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/babel__core": {
@@ -1999,6 +2012,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4678,18 +4696,26 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
+      "dependencies": {
+        "commander": "^2.19.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/kleur": {
@@ -4918,6 +4944,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
+      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
+      "dependencies": {
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-markdown": "^0.6.0",
+        "repeat-string": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-markdown": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
@@ -5052,6 +5092,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
+      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
+      "dependencies": {
+        "katex": "^0.12.0",
+        "micromark": "~2.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -5094,9 +5147,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5543,6 +5596,19 @@
       "dependencies": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
+      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
+      "dependencies": {
+        "mdast-util-math": "^0.1.0",
+        "micromark-extension-math": "^0.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6095,9 +6161,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -7323,9 +7389,9 @@
       }
     },
     "@notionhq/client": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-0.4.11.tgz",
-      "integrity": "sha512-+zT+qBHx8V6Fj3Tj9a4KKfYE4tWhrS/7A5OWRinEjsL5J0GKskQ5EnnLEejptg0COh6BgJShVQLPJXsr0NovLQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.5.tgz",
+      "integrity": "sha512-NobSaeSK0DMuxAIy2pg53Iv850tGFxXYEYacFBQgO634L1uwQv7WQCAdeFQpD3kJiEycQfSYv6RGC5VENEXjiQ==",
       "requires": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
@@ -7451,14 +7517,26 @@
       "dev": true
     },
     "@tryfabric/martian": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.1.1.tgz",
-      "integrity": "sha512-7EC6np65doCeaJHubyoJzYa8dykKw069QQwV1AdRce0Epw4+eOfXQcYmmXnNHpvJYCctst/Nkjo0lQA6H1UPqQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@tryfabric/martian/-/martian-1.2.4.tgz",
+      "integrity": "sha512-g7SP7beaxrjxLnW//vskra07a1jsJowqp07KMouxh4gCwaF+ItHbRZN8O+1dhJivBi3VdasT71BPyk+8wzEreQ==",
       "requires": {
-        "@notionhq/client": "^0.4.5",
+        "@notionhq/client": "^1.0.4",
         "remark-gfm": "^1.0.0",
+        "remark-math": "^4.0.0",
         "remark-parse": "^9.0.0",
         "unified": "^9.2.1"
+      },
+      "dependencies": {
+        "@notionhq/client": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+          "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+          "requires": {
+            "@types/node-fetch": "^2.5.10",
+            "node-fetch": "^2.6.1"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -8116,6 +8194,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -10102,12 +10185,17 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
+    },
+    "katex": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.12.0.tgz",
+      "integrity": "sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==",
       "requires": {
-        "minimist": "^1.2.5"
+        "commander": "^2.19.0"
       }
     },
     "kleur": {
@@ -10275,6 +10363,16 @@
         "mdast-util-to-markdown": "~0.6.0"
       }
     },
+    "mdast-util-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-0.1.2.tgz",
+      "integrity": "sha512-fogAitds+wH+QRas78Yr1TwmQGN4cW/G2WRw5ePuNoJbBSPJCxIOCE8MTzHgWHVSpgkRaPQTgfzXRE1CrwWSlg==",
+      "requires": {
+        "longest-streak": "^2.0.0",
+        "mdast-util-to-markdown": "^0.6.0",
+        "repeat-string": "^1.0.0"
+      }
+    },
     "mdast-util-to-markdown": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
@@ -10364,6 +10462,15 @@
         "micromark": "~2.11.0"
       }
     },
+    "micromark-extension-math": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-0.1.2.tgz",
+      "integrity": "sha512-ZJXsT2eVPM8VTmcw0CPSDeyonOn9SziGK3Z+nkf9Vb6xMPeU+4JMEnO6vzDL10562Favw8Vste74f54rxJ/i6Q==",
+      "requires": {
+        "katex": "^0.12.0",
+        "micromark": "~2.11.0"
+      }
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -10394,9 +10501,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -10714,6 +10821,15 @@
       "requires": {
         "mdast-util-gfm": "^0.1.0",
         "micromark-extension-gfm": "^0.3.0"
+      }
+    },
+    "remark-math": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-4.0.0.tgz",
+      "integrity": "sha512-lH7SoQenXtQrvL0bm+mjZbvOk//YWNuyR+MxV18Qyv8rgFmMEGNuB0TSCQDkoDaiJ40FCnG8lxErc/zhcedYbw==",
+      "requires": {
+        "mdast-util-math": "^0.1.0",
+        "micromark-extension-math": "^0.1.0"
       }
     },
     "remark-parse": {
@@ -11123,9 +11239,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -10,14 +10,18 @@
     "lint": "eslint src",
     "fix": "eslint --fix src"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "notion",
+    "markdown",
+    "release-notes"
+  ],
+  "author": "Josh Potts",
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/github": "^5.0.0",
-    "@notionhq/client": "^0.4.11",
-    "@tryfabric/martian": "^1.1.1"
+    "@notionhq/client": "^2.2.5",
+    "@tryfabric/martian": "^1.2.4"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Notion Release Notes
 
-[![CodeQL](https://github.com/infinitaslearning/notion-release-notes/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/infinitaslearning/notion-release-notes/actions/workflows/codeql-analysis.yml)
+[![CodeQL](https://github.com/jlpdeveloper/notion-markdown-creator/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/jlpdeveloper/notion-markdown-creator/actions/workflows/codeql-analysis.yml)
 
 This action allows you to specify an existing database in your Notion workspace, and create a new entry each time your action runs.  This is currently specifically aimed at release notes, but could be used for a more generic purpose if you like, fields are kept purposefully quite generic.
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# Notion Release Notes
+# Notion Page Creator From Markdown File
+
+Big thanks to [infinitaslearning](https://github.com/infinitaslearning/notion-release-notes) for providing the original release notes creator. This project modifies that code as tables do not seem to be translated properly from raw markdown file content passed to it. This action is my attempt to bypass that by writing the content to file first, then reading it.
 
 [![CodeQL](https://github.com/jlpdeveloper/notion-markdown-creator/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/jlpdeveloper/notion-markdown-creator/actions/workflows/codeql-analysis.yml)
 
@@ -17,37 +19,21 @@ By default integrations cant access any content so you you *must* share your dat
 This action expects a Notion database with the following properties:
 
   - Name: text
-  - Date: date
-  - Tags: tags
 
-You can use the following template and duplicate it: https://infinitaslearning.notion.site/Notion-Release-Notes-a97bedb581464a3ea24159d8eac576c0
-
-It can look like this:
-
-<img width="981" alt="Screenshot 2021-12-18 at 08 55 42" src="https://user-images.githubusercontent.com/239305/146633970-5e1baaf8-6457-4664-b56c-284355e3b241.png">
-
-And each actual page contains whatever your release notes are:
-
-<img width="765" alt="Screenshot 2021-12-18 at 08 56 44" src="https://user-images.githubusercontent.com/239305/146633996-116ff1af-5fe7-4642-ab65-3c0f6ccedf1e.png">
 
 ## Usage
 
 Typically this is used with a changelog builder:
 
 ```yaml
-- name: Release Changelog Builder
-    uses: mikepenz/release-changelog-builder-action@v2.7.1
-    id: build_changelog
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}   
+ 
 - name: Notion release notes        
-  uses: infinitaslearning/notion-release-notes@main        
+  uses: jlpdeveloper/notion-markdown-creator@latest        
   with:          
     token: ${{ secrets.NOTION_TOKEN }}
     database: 619f0845c68a4c18837ebdb9812b90c0
     name: Super Amazing Service    
-    tags: segment,team,service-name
-    body: ${{ steps.build_changelog.outputs.changelog }}
+    filepath: 'readme.md'
 ```
 
 To get the database ID, simply browse to it, click on the '...' and get a 'Copy link'.  The GUID at the end of the URL is the id.

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,15 +8,7 @@ test('complete input should succeed with default inputs', () => {
   process.env.INPUT_DATABASE = '619f0845c68a4c18837ebdb9812b90c0'
   process.env.INPUT_TOKEN = process.env.NOTION_TOKEN
   process.env.INPUT_NAME = 'Awesome release'
-  process.env.INPUT_BODY = `
-## Release notes
-
-- Major changes
-  - https://github.com./infinitaslearning
-
-- Other changes
-  - https://github.com./infinitaslearning
-`
+  process.env.INPUT_FILEPATH = ''
 
   const ip = path.join(__dirname, 'index.js')
   const options = {
@@ -26,25 +18,3 @@ test('complete input should succeed with default inputs', () => {
   expect(result).toBeDefined()
 })
 
-test('complete input should succeed with tags', () => {
-  process.env.INPUT_DATABASE = '619f0845c68a4c18837ebdb9812b90c0'
-  process.env.INPUT_TOKEN = process.env.NOTION_TOKEN
-  process.env.INPUT_NAME = 'Awesome release'
-  process.env.INPUT_TAGS = 'my,awesome,tags'
-  process.env.INPUT_BODY = `
-## Release notes
-
-- Major changes
-  - https://github.com./infinitaslearning
-
-- Other changes
-  - https://github.com./infinitaslearning
-`
-
-  const ip = path.join(__dirname, 'index.js')
-  const options = {
-    env: process.env
-  }
-  const result = cp.execSync(`node ${ip}`, options).toString()
-  expect(result).toBeDefined()
-})


### PR DESCRIPTION
## Changes Made

This github action has been reworked to have more up to date requirements on the package json and will now take in a filepath instead of a markdown body.

The action will read the content from the file path and add to notion. I have also removed the `Date` and `Tags` Requirement from the database. New tags may be added at a later date